### PR TITLE
Add copy confirmation dialog

### DIFF
--- a/src/copy_request.rs
+++ b/src/copy_request.rs
@@ -1,0 +1,8 @@
+use std::path::PathBuf;
+
+#[derive(Clone)]
+pub struct CopyRequest {
+    pub src: PathBuf,
+    pub dest: PathBuf,
+    pub file_count: usize,
+}


### PR DESCRIPTION
## Summary
- add `CopyRequest` struct for pending copy info
- require user confirmation via popup before copying
- report drive detection events and show copy details

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686959410888832a8d8001553125b3d2